### PR TITLE
feat: automate the build

### DIFF
--- a/.build/centos6.sh
+++ b/.build/centos6.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Take a copy of the source files to build in an isolated directory
+mkdir -p /build
+cp -R /vmod-queryfilter/* /build
+cd /build
+
+cat << EOF > /etc/yum.repos.d/varnish.repo
+[varnish]
+name=Varnish Repository
+baseurl=https://packagecloud.io/varnishcache/varnish41/el/6/\$basearch
+enabled=1
+fastestmirror_enabled=0
+gpgcheck=0
+gpgkey=https://packagecloud.io/varnishcache/varnish41/gpgkey
+EOF
+
+yum -q makecache -y --disablerepo='*' --enablerepo='varnish'
+yum install varnish -y
+
+# Varnish version installed
+VERSION=$(rpm --queryformat "%{VERSION}" -q varnish)
+
+wget "https://github.com/varnishcache/varnish-cache/archive/varnish-$VERSION.tar.gz"
+tar -xzf "varnish-$VERSION.tar.gz"
+
+cd "varnish-cache-varnish-$VERSION"
+export VARNISHSRC=$(pwd)
+./autogen.sh && ./configure && make
+
+cd ..
+
+./autogen.sh
+./configure VARNISHSRC=$VARNISHSRC
+make

--- a/.build/debian8.sh
+++ b/.build/debian8.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Take a copy of the source files to build in an isolated directory
+mkdir -p /build
+cp -R /vmod-queryfilter/* /build
+cd /build
+
+curl -L https://packagecloud.io/varnishcache/varnish52/gpgkey | apt-key add -
+
+cat << EOF > /etc/apt/sources.list.d/varnish.list
+deb https://packagecloud.io/varnishcache/varnish5/ubuntu/ trusty main
+deb-src https://packagecloud.io/varnishcache/varnish5/ubuntu/ trusty main
+EOF
+
+apt-get update -y
+apt-get install varnish varnish-dev -y --force-yes
+
+./autogen.sh
+./configure VARNISHSRC=/usr/include/varnish/
+make

--- a/.build/debian8.sh
+++ b/.build/debian8.sh
@@ -16,5 +16,5 @@ apt-get update -y
 apt-get install varnish varnish-dev -y --force-yes
 
 ./autogen.sh
-./configure VARNISHSRC=/usr/include/varnish/
+./configure --enable-query-arrays VARNISHSRC=/usr/include/varnish/
 make

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,9 @@ vmod_queryfilter.3
 
 # Things not to ignore
 !m4/ax_*
+
+# Kitchen CI
+.bundle/
+.kitchen/
+vendor/
+Gemfile.lock

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,46 @@
+---
+driver:
+  name: docker
+  privileged: true
+  use_sudo: false
+  # Share the code into the Kitchen Container
+  volume:
+    - $(pwd):/vmod-queryfilter
+
+platforms:
+  - name: centos-6.9
+    provisioner:
+      script: .build/centos6.sh
+    driver_config:
+      provision_command:
+        # Update & install epel-release & yum-utils
+        - yum update -y
+        - yum install epel-release -y
+        - yum install pygpgme yum-utils wget python-docutils ncurses-devel pcre-devel libedit-devel -y
+        # Install build tools
+        - yum groupinstall 'Development Tools' -y
+
+  - name: debian-8
+    provisioner:
+      script: .build/debian8.sh
+    driver_config:
+      image: debian:8
+      provision_command:
+        # Update & install require packages
+        - apt-get update && apt-get upgrade -y
+        - apt-get install curl gnupg apt-transport-https debian-archive-keyring -y
+        # Install build tools
+        - apt-get install build-essential autotools-dev libtool automake -y
+
+
+provisioner:
+  name: shell
+
+verifier:
+  name: inspec
+
+suites:
+  - name: centos
+    excludes: ["debian-8"]
+  - name: debian
+    excludes: ["centos-6.9"]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: ruby
+dist: trusty
+
+matrix:
+  include:
+    - rvm: 2.3
+      env: suite=centos-69
+#    - rvm: 2.3
+#      env: suite=debian-8
+
+sudo: required
+services: docker
+
+before_script:
+  - gem install bundler
+  - bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --retry=3
+
+script: bundle exec kitchen test "$suite"

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'inspec'
+gem 'test-kitchen'
+gem 'kitchen-docker'
+gem 'kitchen-inspec'
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 libvmod-queryfilter
 ===================
 
+Travis
+-------
+
+[![Build Status](https://travis-ci.org/gsdevme/libvmod-queryfilter.svg?branch=master)](https://travis-ci.org/gsdevme/libvmod-queryfilter)
+
+
 Overview
 --------
 This is a simple VMOD for [Varnish Cache](https://www.varnish-cache.org/) which

--- a/src/vmod_queryfilter.vcc
+++ b/src/vmod_queryfilter.vcc
@@ -1,7 +1,7 @@
 #==============================================================================
 # libvmod-queryfilter: Simple VMOD for filtering/sorting query strings
 #
-# Copyright © 2014-2018 The New York Times Company
+# Copyright 2014-2018 The New York Times Company
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Hey @andrew-canaday 

In regard to https://github.com/NYTimes/libvmod-queryfilter/issues/2 

Ive create a travis file and using kitchen-ci set it to build the package on both CentOS & Debian... likely some more work but just thought Id push the changes to get some thoughts? 

I've ran both suites and screenshot the errors, Debian seems to get further than CentOS though but fails at the `make` point. 

CentOS 6.9
<img width="901" alt="screen shot 2018-01-30 at 21 16 16" src="https://user-images.githubusercontent.com/319498/35591997-9992f8ec-0603-11e8-9a57-de3b6e34568b.png">

Debian 8
<img width="943" alt="screen shot 2018-01-30 at 21 20 54" src="https://user-images.githubusercontent.com/319498/35592008-9fa74fe4-0603-11e8-8ea3-026d323ae660.png">

I also checked the folder you was speaking about.

```
root@674f4c3ba5ab:~# ls -l /usr/include/varnish/
total 140
drwxr-xr-x 2 root root  4096 Jan 30 21:20 cache
drwxr-xr-x 2 root root  4096 Jan 30 21:20 common
-rw-r--r-- 1 root root  1981 Nov 14 15:27 miniobj.h
drwxr-xr-x 2 root root  4096 Jan 30 21:20 tbl
drwxr-xr-x 2 root root  4096 Jan 30 21:20 vapi
-rw-r--r-- 1 root root  3128 Nov 14 15:27 vas.h
-rw-r--r-- 1 root root  1727 Nov 14 15:27 vav.h
-rw-r--r-- 1 root root  4339 Nov 14 15:27 vbm.h
-rw-r--r-- 1 root root  2194 Nov 14 15:27 vcl.h
-rw-r--r-- 1 root root  2572 Nov 14 15:27 vcli.h
-rw-r--r-- 1 root root  1553 Nov 14 15:27 vcs.h
-rw-r--r-- 1 root root  4534 Nov 14 15:27 vdef.h
-rw-r--r-- 1 root root   163 Nov 14 15:27 vmod_abi.h
-rw-r--r-- 1 root root 19914 Nov 14 15:27 vqueue.h
-rw-r--r-- 1 root root  2257 Nov 14 15:27 vre.h
-rw-r--r-- 1 root root  1637 Nov 14 15:27 vrnd.h
-rw-r--r-- 1 root root 10615 Nov 14 15:27 vrt.h
-rw-r--r-- 1 root root  4963 Nov 14 15:27 vrt_obj.h
-rw-r--r-- 1 root root  2235 Nov 14 15:27 vsa.h
-rw-r--r-- 1 root root  3389 Nov 14 15:27 vsb.h
-rw-r--r-- 1 root root  1828 Nov 14 15:27 vsha256.h
-rw-r--r-- 1 root root  2803 Nov 14 15:27 vtcp.h
-rw-r--r-- 1 root root  1740 Nov 14 15:27 vtim.h
-rw-r--r-- 1 root root  2659 Nov 14 15:27 vut.h
-rw-r--r-- 1 root root  3616 Nov 14 15:27 vut_options.h
drwxr-xr-x 2 root root  4096 Jan 30 21:20 waiter
```