### PR TITLE
hack to build against varnish 4.x dev package instead of source

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -92,14 +92,21 @@ AC_CHECK_FUNCS([strchr])
 #-----------------------------
 #           Varnish:
 #-----------------------------
-AX_CHECK_VARNISH_VMOD_DEV([],[
-    AC_MSG_ERROR(["$VARNISHSRC missing or not built."])
-])
+PKG_CHECK_VAR([VARNISH_PREFIX], [varnishapi], [prefix])
+PKG_CHECK_VAR([VARNISH_BINDIR], [varnishapi], [bindir])
+PKG_CHECK_VAR([VARNISH_SBINDIR], [varnishapi], [sbindir])
+PKG_CHECK_VAR([VARNISH_DATAROOT], [varnishapi], [datarootdir])
+
+VARNISH_VMOD_INCLUDES
+VARNISH_VMOD_DIR
+VARNISH_VMODTOOL
+
+AC_SUBST([VARNISH_API_MAJOR],[4])
+
 AC_DEFINE_UNQUOTED(
     [VARNISH_API_MAJOR],
     [$VARNISH_API_MAJOR],
     [Varnish API major version])
-
 
 AM_CONDITIONAL([VARNISHSRC_3_X],[test "x$VARNISH_API_MAJOR" = "x3"])
 AM_CONDITIONAL([VARNISHSRC_4_X],[test "x$VARNISH_API_MAJOR" = "x4"])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,6 +5,7 @@
 #=============================================================================
 
 AM_CPPFLAGS = \
+    $(VMOD_INCLUDES) \
     -I@VARNISHSRC@/include \
     -I@VARNISHSRC@/bin/varnishd \
     -I@VARNISHSRC@ \
@@ -30,7 +31,10 @@ vcc_if.c vcc_if.h: @top_srcdir@/src/vmod_queryfilter.vcc
 endif
 
 if VARNISHSRC_4_X
-vcc_if.c vcc_if.h: @top_srcdir@/src/vmod_queryfilter4.vcc
+config.h: ../vmod_queryfilter_config.h
+	cp ../vmod_queryfilter_config.h config.h
+
+vcc_if.c vcc_if.h: @top_srcdir@/src/vmod_queryfilter4.vcc config.h
 	@PYTHON@ @VMODTOOL@ @top_srcdir@/src/vmod_queryfilter4.vcc
 endif
 


### PR DESCRIPTION
Hey. Just wanted to put this out there. As we only use the varnish 4.x variant of the mod at present, we've been using this hack to build against the upstream varnish-dev deb package for ubuntu instead of a source dir. (https://packagecloud.io/varnishcache/varnish41)

Won't work for varnish3 builds, since the VARNISH_VMOD* autoconf macros were introduced in the varnish 4 packaging.

The motivation is that I wanted to avoid rebuilding varnish from source to build this vmod.

Not at all expecting this to be applied, but use it as inspiration if you wish, if you're planning to drop varnish3 support.